### PR TITLE
debugging p-many

### DIFF
--- a/src/turning/markdown.clj
+++ b/src/turning/markdown.clj
@@ -45,7 +45,16 @@
             (p/p-or bold->b italic->i)))
   #_(p/p-any word whitespace bold italic))
 
+;p-many strange behaviour
+(text "a")
+(text "ab")
+
+(def pmanytest (p/p-many word))
+;(pmanytest "ab f")
+
+
 (def nl (p/p-char \newline))
+
 (def indent (p/p-times space 2))
 
 (def uli (p/p-seq (p/p-times space 2)

--- a/src/turning/parser.clj
+++ b/src/turning/parser.clj
@@ -89,24 +89,55 @@
                  (nonparsed r))
         r))))
 
+
+
+(defn debugf
+  " extracts info of clojure objects in a specific way and builds a string
+    turn: turning.parser$p_char$fn__3887@2bd08263 
+    into: p_char@2bd08263
+  "
+  [func]
+  
+  (let [string_vector  (clojure.string/split (str func) #"\$")]
+    (str (get string_vector 1) "@" (get (clojure.string/split (str func) #"@") 1))
+    )
+  )
+
+
+
 (defn p-many
   "Parses 0 or more times"
   [p]
   (fn [s]
+    (println (str  "\nINIT:  " (debugf  p) " " s))
     (loop [r (p s)
            accum ""
            rest s]
+      (println (str 
+                "        -> "
+                "call: (" (debugf p) 
+                " '" s "') "
+                " accum: " accum
+                " rest: " s
+                ))
       (if (failure? r)
-        (success accum rest)
+        (do (println (str  " OUTPUT1(" (debugf  p) "):" (success accum rest) "\n" ))
+            ;maybe this should not be always a success?
+            ;no! it should always be sucess as p-many parses 0 or more 
+            (success accum rest))
         (let [parsed (parsed r)
               nonparsed (nonparsed r)]
           (if (empty? nonparsed)
-            (success (str accum parsed) nonparsed)
+            (do (println (str  " OUTPUT2(" (debugf  p) "):" (success (str accum parsed) nonparsed) "\n" ))
+                (success (str accum parsed) nonparsed))
             (do
               #_(prn (str  "parsed: " (str accum parsed) " nonparsed: " nonparsed))
               (recur (p nonparsed)
                      (str accum parsed)
                      nonparsed))))))))
+
+;how this p-many can become an infinite loop?
+
 
 (defn p-many1
   "Parses 1 or more times"


### PR DESCRIPTION
It seems that p-many doesn't always works as expected. Sometimes it enters an infinite loop. I added println debugging instructions to p-many function to try to understand how this function works internally.

The println statements show different points of the p-many function: "INIT"(before loop)," ->call" (just after entering a loop) and "OUTPUT" (on the 2 exit points of the loop). It adds the internal identifier of the p function to be able to differentiate between different executions of the p-many function. The result for (text "a") is somehow not clear to me:

```
INIT:  p_or@79ed7ed9 a

INIT:  p_or@49789ee3 a
        -> call: (p_or@49789ee3 'a')  accum:  rest: a
 OUTPUT2(p_or@49789ee3):{:success ["a" ""]}

INIT:  p_char@174341ac a
        -> call: (p_char@174341ac 'a')  accum:  rest: a
 OUTPUT1(p_char@174341ac):{:success ["" "a"]}
        -> call: (p_or@79ed7ed9 'a')  accum:  rest: a
 OUTPUT2(p_or@79ed7ed9):{:success ["a" ""]}
```
Any ideas?
